### PR TITLE
fix(generator): use Generator.RESOURCE_PATH instead of Analyser.RESOURCE_PATH

### DIFF
--- a/python/mlmorph/analyser.py
+++ b/python/mlmorph/analyser.py
@@ -5,10 +5,10 @@ Simple python interface for mlmorph using sfst
 """
 
 from importlib import resources
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import regex
-import sfst
+import sfst  # ty: ignore[unresolved-import]
 
 from .foreign_word_detector import check_foreign_word
 from .normalizer import normalize
@@ -22,9 +22,9 @@ class Analyser:
 
     def __init__(self):
         """Construct Mlmorph Analyser"""
-        self.fsa: str = None
+        self.fsa: str | None = None
         if resources.files('mlmorph').joinpath(Analyser.RESOURCE_PATH).is_file():
-            self.fsa: str = str(resources.files('mlmorph').joinpath(Analyser.RESOURCE_PATH))
+            self.fsa = str(resources.files('mlmorph').joinpath(Analyser.RESOURCE_PATH))
         if not self.fsa:
             raise ValueError("Could not read the fsa.")
         sfst.init(self.fsa)
@@ -32,7 +32,7 @@ class Analyser:
 
     def analyse(
         self, word: str, weighted: bool = True, foreign_word_check: bool = True
-    ) -> List[Tuple[str, int]]:
+    ) -> List[str] | List[Tuple[str, int]]:
         """
         Perform a simple morphological analysis lookup.
 
@@ -116,7 +116,7 @@ class Analyser:
         return result
 
     @staticmethod
-    def get_weight(analysis: str) -> int:
+    def get_weight(analysis: List[dict[str, Any]]) -> int:
         """Analysis with less weight is the best analysis."""
         morpheme_length = len(analysis)
         weight = morpheme_length * 100

--- a/python/mlmorph/generator.py
+++ b/python/mlmorph/generator.py
@@ -5,9 +5,9 @@ Simple python interface for mlmorph using sfst
 """
 
 from importlib import resources
-from typing import Tuple
+from typing import List, Tuple
 
-import sfst
+import sfst  # ty: ignore[unresolved-import]
 
 from .analyser import Analyser
 from .normalizer import normalize
@@ -18,9 +18,9 @@ class Generator:
 
     def __init__(self):
         """Construct Mlmorph Generator"""
-        self.fsa: str = None
+        self.fsa: str | None = None
         if resources.files('mlmorph').joinpath(Generator.RESOURCE_PATH).is_file():
-            self.fsa: str = str(resources.files('mlmorph').joinpath(Analyser.RESOURCE_PATH))
+            self.fsa: str = str(resources.files('mlmorph').joinpath(Generator.RESOURCE_PATH))
         if not self.fsa:
             raise ValueError('Could not read the fsa.')
         sfst.init(self.fsa)
@@ -43,7 +43,7 @@ class Generator:
                 return weight+i
         return weight+len(generated_word)
 
-    def generate(self, token: str, weighted: bool = True) -> Tuple:
+    def generate(self, token: str, weighted: bool = True) -> List[Tuple[str, int]] | Tuple:
         """Perform a simple morphological generator lookup."""
         token = normalize(token)
         generated_results = sfst.generate(token)
@@ -57,4 +57,3 @@ class Generator:
             processed_result.append(
                 (generated_results[gindex], generated_result_weight))
         return sorted(processed_result, key=lambda tup: tup[1])
-

--- a/python/test/unit/test_module_integrity.py
+++ b/python/test/unit/test_module_integrity.py
@@ -1,0 +1,30 @@
+"""Tests for module-level invariants that don't require a compiled FSA."""
+
+import ast
+import inspect
+import textwrap
+
+from mlmorph.generator import Generator
+
+
+def test_generator_init_uses_own_resource_path():
+    """Bug #1: Generator.__init__ must reference Generator.RESOURCE_PATH, not Analyser's."""
+    source = inspect.getsource(Generator.__init__)
+    tree = ast.parse(textwrap.dedent(source))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "RESOURCE_PATH"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "Analyser"
+        ):
+            raise AssertionError(
+                "Generator.__init__ references Analyser.RESOURCE_PATH; "
+                "it should reference Generator.RESOURCE_PATH"
+            )
+
+
+def test_generator_resource_path_attribute_exists():
+    """Generator must declare its own RESOURCE_PATH, not rely on Analyser's."""
+    assert hasattr(Generator, "RESOURCE_PATH"), "Generator is missing RESOURCE_PATH"
+    assert isinstance(Generator.RESOURCE_PATH, str)


### PR DESCRIPTION
## Bug

`Generator.__init__` checked for the FSA file using `Generator.RESOURCE_PATH` but loaded `self.fsa` using `Analyser.RESOURCE_PATH` (line 23):

```python
# check uses Generator.RESOURCE_PATH ✓
if resources.files('mlmorph').joinpath(Generator.RESOURCE_PATH).is_file():
    # assignment uses Analyser.RESOURCE_PATH ✗
    self.fsa: str = str(resources.files('mlmorph').joinpath(Analyser.RESOURCE_PATH))
```

Both constants are `'data/malayalam.a'` today so the bug is silent. Any future divergence between the two paths would cause `Generator` to load from the wrong location while the existence check passes on a completely different path.

## Fix

Replace `Analyser.RESOURCE_PATH` with `Generator.RESOURCE_PATH` on the assignment line so both the check and the load reference the same class-owned constant.

## Type annotation fixes (found via `ty` during this investigation)

- `generator.py`: `self.fsa: str = None` → `str | None = None`; `generate()` return type narrowed to `List[Tuple[str, int]] | Tuple`; added `List` import
- `analyser.py`: same `str | None` fix on `self.fsa`; `analyse()` return type corrected to `List[str] | List[Tuple[str, int]]` (unweighted path returns `List[str]`, not `List[Tuple]`); `get_weight()` parameter type corrected from `str` to `List[dict[str, Any]]` — it receives the parsed morphemes list, not a string; both files annotated with `# ty: ignore[unresolved-import]` on `import sfst` since sfst is a C extension with no stub files

## Test

`test_module_integrity.py` uses `ast.walk` to assert that `Generator.__init__` contains no `Attribute` node referencing `Analyser.RESOURCE_PATH`, catching any future re-introduction without requiring the compiled FSA binary.

## Test plan
- [ ] `pytest python/test/unit/test_module_integrity.py` passes
- [ ] `ruff check python/mlmorph/` passes
- [ ] `ty check python/mlmorph/generator.py python/mlmorph/analyser.py` passes