### PR TITLE
fix(__init__): replace function objects with quoted strings in __all__

### DIFF
--- a/python/mlmorph/__init__.py
+++ b/python/mlmorph/__init__.py
@@ -4,4 +4,4 @@ from .foreign_word_detector import check_foreign_word
 from .generator import Generator
 from .utils import tokenize
 
-__all__ = ['Generator', 'Analyser', 'check_foreign_word', tokenize, normalize]
+__all__ = ['Generator', 'Analyser', 'check_foreign_word', 'tokenize', 'normalize']

--- a/python/test/unit/test_all_exports.py
+++ b/python/test/unit/test_all_exports.py
@@ -1,0 +1,24 @@
+"""Tests for the public API surface exposed via __all__."""
+
+import mlmorph
+
+
+def test_all_entries_are_strings():
+    """Bug #2: __all__ must contain only strings, not function objects.
+
+    Bare function references in __all__ cause `from mlmorph import *` to raise
+    TypeError at import time. Every entry must be the quoted name of the symbol.
+    """
+    for entry in mlmorph.__all__:
+        assert isinstance(entry, str), (
+            f"__all__ entry {entry!r} is not a string — "
+            f"use the quoted name '{entry.__name__}' instead"
+        )
+
+
+def test_all_exports_are_importable():
+    """Every name in __all__ must be resolvable as an attribute of the module."""
+    for name in mlmorph.__all__:
+        assert hasattr(mlmorph, name), (
+            f"'{name}' is listed in __all__ but not importable from mlmorph"
+        )


### PR DESCRIPTION
## Bug

`mlmorph/__init__.py` listed bare function references in `__all__`:

```python
__all__ = ['Generator', 'Analyser', 'check_foreign_word', tokenize, normalize]
```

`tokenize` and `normalize` are function objects, not strings. Python's import machinery requires `__all__` to be a sequence of strings — when it encounters a non-string entry it raises `TypeError`. Any downstream code using `from mlmorph import *` fails at import time with:

```
TypeError: expected str ... got <function tokenize at 0x...>
```

The root cause was likely copy-paste from the import lines above where the names appear without quotes.

## Fix

Quote the two names so `__all__` contains only strings:

```python
__all__ = ['Generator', 'Analyser', 'check_foreign_word', 'tokenize', 'normalize']
```

No runtime behaviour change beyond making wildcard imports work correctly.

## Test

`test_all_exports.py` adds two checks that run without a compiled FSA:
- `test_all_entries_are_strings`: asserts every `__all__` entry is a `str`, with a helpful error message naming the offending function object
- `test_all_exports_are_importable`: asserts every `__all__` name resolves as an attribute on the module, catching any future stale entries

## Test plan
- [ ] `pytest python/test/unit/test_all_exports.py` passes
- [ ] `from mlmorph import *` works in a Python REPL without raising `TypeError`