### PR TITLE
fix(tox): replace non-existent requirements.txt with pyproject.toml extras

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Malayalam morphology analyser"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["Malayalam", "morphology", "FST", "analyser", "generator", "spellchecker"]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,25 +1,24 @@
 [tox]
 minversion = 3.8.0
-envlist = lint, unit, py{38,39,310,311, 312}
+envlist = lint, unit, py{310,311,312}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.8: py38, unit
-    3.9: py39, unit
     3.10: py310, unit
-    3.11: py311, lint, unit
+    3.11: py311, unit
     3.12: py312, lint, unit
 
 [testenv:unit]
 description = Unit test
-deps = -r{toxinidir}/requirements.txt
+extras = tests
 commands =
     python -m pytest -v
 
 [testenv:lint]
 description = lint source code
-deps = -r{toxinidir}/requirements.txt
+deps =
+    ruff>=0.6.4
 commands =
     ruff check .
     ruff format --check .


### PR DESCRIPTION
## Bug

Both `[testenv:unit]` and `[testenv:lint]` in `tox.ini` referenced:

```ini
deps = -r{toxinidir}/requirements.txt
```

`python/requirements.txt` does not exist. Every `tox` invocation fails immediately with a file-not-found error before any tests or lint checks run. The entire CI matrix (`py310`, `py311`, `py312`, `lint`, `unit`) is broken when driven through tox.

Additionally, `requires-python = ">=3.8"` in `pyproject.toml` is incompatible with the only installable `sfst` release: `sfst==1.10.0` requires Python `>=3.10`. Modern resolvers (uv, pip ≥24) treat the declared range as authoritative and fail to find a satisfying `sfst` version, making the project's dependencies unsatisfiable.

## Fix

**`tox.ini`**
- `[testenv:unit]`: replace `deps = -r requirements.txt` with `extras = tests` — tox installs the package with its `[tests]` extra (pytest), no external file needed
- `[testenv:lint]`: replace `deps = -r requirements.txt` with inline `deps = ruff>=0.6.4`, matching the version floor in `pyproject.toml` dev extras
- Remove Python 3.8 and 3.9 from `envlist` and `gh-actions` matrix — `sfst>=1.6.0` requires Python `>=3.10`, so those entries always resolve to an unsatisfiable dependency set

**`pyproject.toml`**
- `requires-python`: `">=3.8"` → `">=3.10"` to match the actual constraint imposed by `sfst==1.10.0`

## Test plan
- [ ] `tox --listenvs` lists `lint unit py310 py311 py312` without error
- [ ] `tox -e unit` installs pytest from the `[tests]` extra and runs without a missing-file error
- [ ] `uv sync --extra tests --extra dev` resolves successfully